### PR TITLE
feat: add secure forgot password with email/OTP flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.0'  // API module
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.0' // Impl module

--- a/src/main/java/com/jomariabejo/connectly_api/ConnectlyApiApplication.java
+++ b/src/main/java/com/jomariabejo/connectly_api/ConnectlyApiApplication.java
@@ -3,12 +3,16 @@ package com.jomariabejo.connectly_api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
 @RestController
+@EnableScheduling
+@EnableCaching
 public class ConnectlyApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jomariabejo/connectly_api/controller/AuthenticationController.java
+++ b/src/main/java/com/jomariabejo/connectly_api/controller/AuthenticationController.java
@@ -3,6 +3,9 @@ package com.jomariabejo.connectly_api.controller;
 import com.jomariabejo.connectly_api.dto.LoginResponse;
 import com.jomariabejo.connectly_api.dto.RegisterUserDto;
 import com.jomariabejo.connectly_api.dto.LoginUserDto;
+import com.jomariabejo.connectly_api.dto.ForgotPasswordRequest;
+import com.jomariabejo.connectly_api.dto.ResetPasswordRequest;
+import com.jomariabejo.connectly_api.dto.GenericResponse;
 import com.jomariabejo.connectly_api.model.User;
 import com.jomariabejo.connectly_api.model.VerificationToken;
 import com.jomariabejo.connectly_api.repository.UserRepository;
@@ -114,6 +117,51 @@ public class AuthenticationController {
             return ResponseEntity.ok("Email verified successfully. You can now login.");
         } else {
             return ResponseEntity.badRequest().body("Invalid or expired verification token");
+        }
+    }
+
+    @PostMapping("/forgot-password/email")
+    public ResponseEntity<GenericResponse<String>> forgotPasswordEmail(@Valid @RequestBody ForgotPasswordRequest request) {
+        log.info("Password reset requested via email for: {}", request.getEmail());
+        try {
+            authenticationService.initiatePasswordResetEmail(request.getEmail());
+            return ResponseEntity.ok(new GenericResponse<>(
+                "If an account exists with this email, you will receive a password reset link shortly.", null));
+        } catch (Exception e) {
+            log.error("Error processing email password reset", e);
+            return ResponseEntity.status(429).body(new GenericResponse<>(
+                "Too many requests. Please try again later.", null));
+        }
+    }
+
+    @PostMapping("/forgot-password/otp")
+    public ResponseEntity<GenericResponse<String>> forgotPasswordOtp(@Valid @RequestBody ForgotPasswordRequest request) {
+        log.info("Password reset requested via OTP for: {}", request.getEmail());
+        try {
+            authenticationService.initiatePasswordResetOtp(request.getEmail());
+            return ResponseEntity.ok(new GenericResponse<>(
+                "If an account exists with this email, you will receive a verification code shortly.", null));
+        } catch (Exception e) {
+            log.error("Error processing OTP password reset", e);
+            return ResponseEntity.status(429).body(new GenericResponse<>(
+                "Too many requests. Please try again later.", null));
+        }
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<GenericResponse<String>> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        log.info("Password reset attempt initiated");
+        try {
+            authenticationService.resetPassword(request.getToken(), request.getOtp(), request.getNewPassword());
+            return ResponseEntity.ok(new GenericResponse<>(
+                "Your password has been successfully reset. You can now login with your new password.", null));
+        } catch (RuntimeException e) {
+            log.error("Error resetting password: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(new GenericResponse<>(e.getMessage(), null));
+        } catch (Exception e) {
+            log.error("Unexpected error during password reset", e);
+            return ResponseEntity.status(500).body(new GenericResponse<>(
+                "An error occurred while resetting your password. Please try again later.", null));
         }
     }
 }

--- a/src/main/java/com/jomariabejo/connectly_api/dto/ForgotPasswordRequest.java
+++ b/src/main/java/com/jomariabejo/connectly_api/dto/ForgotPasswordRequest.java
@@ -1,0 +1,12 @@
+package com.jomariabejo.connectly_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForgotPasswordRequest {
+    private String email;
+}

--- a/src/main/java/com/jomariabejo/connectly_api/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/jomariabejo/connectly_api/dto/ResetPasswordRequest.java
@@ -1,0 +1,14 @@
+package com.jomariabejo.connectly_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetPasswordRequest {
+    private String token;
+    private String otp;
+    private String newPassword;
+}

--- a/src/main/java/com/jomariabejo/connectly_api/exception/InvalidPasswordResetTokenException.java
+++ b/src/main/java/com/jomariabejo/connectly_api/exception/InvalidPasswordResetTokenException.java
@@ -1,0 +1,11 @@
+package com.jomariabejo.connectly_api.exception;
+
+public class InvalidPasswordResetTokenException extends RuntimeException {
+    public InvalidPasswordResetTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidPasswordResetTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/exception/PasswordResetAttemptsExceededException.java
+++ b/src/main/java/com/jomariabejo/connectly_api/exception/PasswordResetAttemptsExceededException.java
@@ -1,0 +1,11 @@
+package com.jomariabejo.connectly_api.exception;
+
+public class PasswordResetAttemptsExceededException extends RuntimeException {
+    public PasswordResetAttemptsExceededException(String message) {
+        super(message);
+    }
+
+    public PasswordResetAttemptsExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/exception/PasswordResetTokenExpiredException.java
+++ b/src/main/java/com/jomariabejo/connectly_api/exception/PasswordResetTokenExpiredException.java
@@ -1,0 +1,11 @@
+package com.jomariabejo.connectly_api.exception;
+
+public class PasswordResetTokenExpiredException extends RuntimeException {
+    public PasswordResetTokenExpiredException(String message) {
+        super(message);
+    }
+
+    public PasswordResetTokenExpiredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/model/PasswordResetToken.java
+++ b/src/main/java/com/jomariabejo/connectly_api/model/PasswordResetToken.java
@@ -1,0 +1,86 @@
+package com.jomariabejo.connectly_api.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.Calendar;
+
+@Data
+@Entity
+@Table(name = "password_reset_token")
+public class PasswordResetToken {
+    private static final int EXPIRATION_MINUTES = 15;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String token;
+
+    @Column(nullable = true)
+    private String otp;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TokenType tokenType;
+
+    @ManyToOne(targetEntity = User.class, fetch = FetchType.EAGER)
+    @JoinColumn(nullable = false, name = "user_id")
+    private User user;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private Date createdAt;
+
+    @Column(nullable = false)
+    private Date expiryDate;
+
+    @Column(nullable = false)
+    private boolean isUsed = false;
+
+    @Column(nullable = false)
+    private int attemptCount = 0;
+
+    public PasswordResetToken() {
+    }
+
+    public PasswordResetToken(String token, User user) {
+        this.token = token;
+        this.user = user;
+        this.tokenType = TokenType.LINK;
+        this.isUsed = false;
+        this.attemptCount = 0;
+        this.expiryDate = calculateExpiryDate(EXPIRATION_MINUTES);
+    }
+
+    public PasswordResetToken(String token, String otp, User user, TokenType tokenType) {
+        this.token = token;
+        this.otp = otp;
+        this.user = user;
+        this.tokenType = tokenType;
+        this.isUsed = false;
+        this.attemptCount = 0;
+        this.expiryDate = calculateExpiryDate(EXPIRATION_MINUTES);
+    }
+
+    private Date calculateExpiryDate(int expiryTimeInMinutes) {
+        java.util.Calendar cal = java.util.Calendar.getInstance();
+        cal.setTime(new Timestamp(cal.getTime().getTime()));
+        cal.add(java.util.Calendar.MINUTE, expiryTimeInMinutes);
+        return new Date(cal.getTime().getTime());
+    }
+
+    public boolean isExpired() {
+        Calendar cal = Calendar.getInstance();
+        return cal.getTime().after(this.expiryDate);
+    }
+
+    public enum TokenType {
+        LINK,
+        OTP
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/jomariabejo/connectly_api/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,31 @@
+package com.jomariabejo.connectly_api.repository;
+
+import com.jomariabejo.connectly_api.model.PasswordResetToken;
+import com.jomariabejo.connectly_api.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+    Optional<PasswordResetToken> findByToken(String token);
+
+    Optional<PasswordResetToken> findByOtp(String otp);
+
+    @Query("SELECT p FROM PasswordResetToken p WHERE p.user = :user AND p.isUsed = false AND p.expiryDate > CURRENT_TIMESTAMP")
+    Optional<PasswordResetToken> findUnexpiredByUser(@Param("user") User user);
+
+    @Query("SELECT p FROM PasswordResetToken p WHERE p.user = :user AND p.isUsed = false")
+    List<PasswordResetToken> findAllUnusedByUser(@Param("user") User user);
+
+    @Query("SELECT p FROM PasswordResetToken p WHERE p.user = :user")
+    List<PasswordResetToken> findAllByUser(@Param("user") User user);
+
+    @Query("SELECT p FROM PasswordResetToken p WHERE p.expiryDate < CURRENT_TIMESTAMP AND p.isUsed = false")
+    List<PasswordResetToken> findExpiredTokens();
+}

--- a/src/main/java/com/jomariabejo/connectly_api/scheduled/PasswordResetTokenCleanupTask.java
+++ b/src/main/java/com/jomariabejo/connectly_api/scheduled/PasswordResetTokenCleanupTask.java
@@ -1,0 +1,31 @@
+package com.jomariabejo.connectly_api.scheduled;
+
+import com.jomariabejo.connectly_api.service.PasswordResetTokenService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordResetTokenCleanupTask {
+    private static final Logger logger = LoggerFactory.getLogger(PasswordResetTokenCleanupTask.class);
+
+    private final PasswordResetTokenService passwordResetTokenService;
+
+    /**
+     * Scheduled task to delete expired password reset tokens
+     * Runs every hour (3600000 ms)
+     */
+    @Scheduled(fixedRateString = "${security.password.reset.cleanup-interval:3600000}")
+    public void cleanupExpiredTokens() {
+        logger.info("Starting password reset token cleanup task");
+        try {
+            passwordResetTokenService.deleteExpiredTokens();
+            logger.info("Password reset token cleanup completed successfully");
+        } catch (Exception e) {
+            logger.error("Error during password reset token cleanup", e);
+        }
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/service/AuditService.java
+++ b/src/main/java/com/jomariabejo/connectly_api/service/AuditService.java
@@ -1,0 +1,87 @@
+package com.jomariabejo.connectly_api.service;
+
+import com.jomariabejo.connectly_api.model.User;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class AuditService {
+    private static final Logger logger = LoggerFactory.getLogger(AuditService.class);
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * Logs password reset initiation (email or OTP request)
+     */
+    public void logPasswordResetInitiated(User user, String method) {
+        logger.info(
+            "PASSWORD_RESET_INITIATED | timestamp={} | userId={} | email={} | method={} | ipAddress={}",
+            dateFormat.format(new Date()),
+            user.getId(),
+            user.getEmail(),
+            method,
+            getClientIp()
+        );
+    }
+
+    /**
+     * Logs password reset attempt (success or failure)
+     */
+    public void logPasswordReset(User user, boolean success, String method, String reason) {
+        String status = success ? "SUCCESS" : "FAILURE";
+        logger.info(
+            "PASSWORD_RESET_ATTEMPT | timestamp={} | userId={} | email={} | method={} | status={} | reason={} | ipAddress={}",
+            dateFormat.format(new Date()),
+            user.getId(),
+            user.getEmail(),
+            method,
+            status,
+            reason,
+            getClientIp()
+        );
+    }
+
+    /**
+     * Logs invalid password reset attempts
+     */
+    public void logInvalidResetAttempt(String email, String method, String reason) {
+        logger.warn(
+            "PASSWORD_RESET_INVALID_ATTEMPT | timestamp={} | email={} | method={} | reason={} | ipAddress={}",
+            dateFormat.format(new Date()),
+            email,
+            method,
+            reason,
+            getClientIp()
+        );
+    }
+
+    /**
+     * Logs rate limit exceeded events
+     */
+    public void logRateLimitExceeded(String email, String action) {
+        logger.warn(
+            "PASSWORD_RESET_RATE_LIMIT_EXCEEDED | timestamp={} | email={} | action={} | ipAddress={}",
+            dateFormat.format(new Date()),
+            email,
+            action,
+            getClientIp()
+        );
+    }
+
+    /**
+     * Get client IP address from request context
+     * (In a real implementation, you would extract this from HttpServletRequest)
+     */
+    private String getClientIp() {
+        try {
+            return java.net.InetAddress.getLocalHost().getHostAddress();
+        } catch (java.net.UnknownHostException e) {
+            return "UNKNOWN";
+        }
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/service/AuthenticationService.java
+++ b/src/main/java/com/jomariabejo/connectly_api/service/AuthenticationService.java
@@ -3,10 +3,14 @@ package com.jomariabejo.connectly_api.service;
 import com.jomariabejo.connectly_api.dto.RegisterUserDto;
 import com.jomariabejo.connectly_api.dto.LoginUserDto;
 import com.jomariabejo.connectly_api.exception.UnauthorizedAccessException;
+import com.jomariabejo.connectly_api.exception.InvalidPasswordResetTokenException;
+import com.jomariabejo.connectly_api.exception.PasswordResetTokenExpiredException;
 import com.jomariabejo.connectly_api.model.User;
+import com.jomariabejo.connectly_api.model.PasswordResetToken;
 import com.jomariabejo.connectly_api.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -35,18 +39,33 @@ public class AuthenticationService {
 
     private static final Logger logger = LoggerFactory.getLogger(AuthenticationService.class);
     private final VerificationTokenService verificationTokenService;
+    private final PasswordResetTokenService passwordResetTokenService;
+    private final RateLimitingService rateLimitingService;
+    private final AuditService auditService;
+
+    @Value("${security.password.validation.min-length:8}")
+    private int passwordMinLength;
+
+    @Value("${app.password-reset.redirect-url:http://localhost:8080/reset-password}")
+    private String passwordResetRedirectUrl;
 
     public AuthenticationService(
             UserRepository userRepository,
             AuthenticationManager authenticationManager,
             PasswordEncoder passwordEncoder,
             EmailService emailService,
-            VerificationTokenService verificationTokenService) {
+            VerificationTokenService verificationTokenService,
+            PasswordResetTokenService passwordResetTokenService,
+            RateLimitingService rateLimitingService,
+            AuditService auditService) {
         this.authenticationManager = authenticationManager;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.emailService = emailService;
         this.verificationTokenService = verificationTokenService;
+        this.passwordResetTokenService = passwordResetTokenService;
+        this.rateLimitingService = rateLimitingService;
+        this.auditService = auditService;
     }
 
     public User signup(RegisterUserDto registerUserDto) {
@@ -115,5 +134,157 @@ public class AuthenticationService {
         return userRepository.save(user);
     }
 
+    /**
+     * Initiates password reset flow via email link
+     */
+    public void initiatePasswordResetEmail(String email) {
+        logger.debug("Initiating password reset email flow for: {}", email);
+
+        // Check rate limiting
+        if (rateLimitingService.isRateLimited(email, "forgot_password_email")) {
+            auditService.logRateLimitExceeded(email, "forgot_password_email");
+            throw new RuntimeException("Too many password reset requests. Please try again later.");
+        }
+
+        // Record the attempt
+        rateLimitingService.recordAttempt(email, "forgot_password_email");
+
+        // Check if user exists
+        Optional<User> userOpt = userRepository.findByEmail(email);
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            auditService.logPasswordResetInitiated(user, "EMAIL_LINK");
+
+            // Create reset token
+            String resetToken = passwordResetTokenService.createEmailResetToken(user);
+
+            // Send email with reset link
+            String resetLink = passwordResetRedirectUrl + "?token=" + resetToken;
+            emailService.sendPasswordResetEmailWithLink(email, resetLink);
+
+            logger.info("Password reset email sent to: {}", email);
+        } else {
+            // Log invalid attempt but don't reveal if email exists
+            auditService.logInvalidResetAttempt(email, "EMAIL_LINK", "Email not found");
+            logger.debug("Password reset requested for non-existent email: {}", email);
+        }
+
+        // Always return success to prevent email enumeration
+    }
+
+    /**
+     * Initiates password reset flow via OTP
+     */
+    public void initiatePasswordResetOtp(String email) {
+        logger.debug("Initiating password reset OTP flow for: {}", email);
+
+        // Check rate limiting
+        if (rateLimitingService.isRateLimited(email, "forgot_password_otp")) {
+            auditService.logRateLimitExceeded(email, "forgot_password_otp");
+            throw new RuntimeException("Too many password reset requests. Please try again later.");
+        }
+
+        // Record the attempt
+        rateLimitingService.recordAttempt(email, "forgot_password_otp");
+
+        // Check if user exists
+        Optional<User> userOpt = userRepository.findByEmail(email);
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            auditService.logPasswordResetInitiated(user, "OTP");
+
+            // Create reset OTP
+            String otp = passwordResetTokenService.createOtpResetToken(user);
+
+            // Send email with OTP
+            emailService.sendPasswordResetOtp(email, otp);
+
+            logger.info("Password reset OTP sent to: {}", email);
+        } else {
+            // Log invalid attempt but don't reveal if email exists
+            auditService.logInvalidResetAttempt(email, "OTP", "Email not found");
+            logger.debug("Password reset requested for non-existent email: {}", email);
+        }
+
+        // Always return success to prevent email enumeration
+    }
+
+    /**
+     * Resets user password using either token or OTP
+     */
+    public void resetPassword(String token, String otp, String newPassword) {
+        logger.debug("Processing password reset request");
+
+        // Validate password strength
+        if (!isPasswordStrong(newPassword)) {
+            throw new RuntimeException(
+                "Password must be at least " + passwordMinLength + 
+                " characters long and contain uppercase, number, and special character"
+            );
+        }
+
+        PasswordResetToken resetToken = null;
+        String resetMethod = null;
+
+        // Validate either token or OTP
+        if (token != null && !token.trim().isEmpty()) {
+            logger.debug("Validating reset token");
+            resetToken = passwordResetTokenService.validateToken(token);
+            resetMethod = "EMAIL_LINK";
+        } else if (otp != null && !otp.trim().isEmpty()) {
+            logger.debug("Validating reset OTP");
+            resetToken = passwordResetTokenService.validateOtp(otp);
+            resetMethod = "OTP";
+        } else {
+            logger.warn("No valid token or OTP provided for password reset");
+            throw new InvalidPasswordResetTokenException("Either token or OTP is required");
+        }
+
+        User user = resetToken.getUser();
+
+        try {
+            // Update password
+            user.setPassword(passwordEncoder.encode(newPassword));
+            userRepository.save(user);
+
+            // Mark token as used
+            passwordResetTokenService.markTokenAsUsed(resetToken);
+
+            auditService.logPasswordReset(user, true, resetMethod, "Password successfully reset");
+            logger.info("Password reset successful for user: {}", user.getEmail());
+        } catch (Exception e) {
+            auditService.logPasswordReset(user, false, resetMethod, "Error during reset: " + e.getMessage());
+            logger.error("Error resetting password for user: {}", user.getEmail(), e);
+            throw new RuntimeException("Failed to reset password", e);
+        }
+    }
+
+    /**
+     * Validates password strength
+     */
+    private boolean isPasswordStrong(String password) {
+        if (password == null || password.length() < passwordMinLength) {
+            return false;
+        }
+
+        // Check for uppercase letter
+        if (!password.matches(".*[A-Z].*")) {
+            return false;
+        }
+
+        // Check for number
+        if (!password.matches(".*[0-9].*")) {
+            return false;
+        }
+
+        // Check for special character
+        if (!password.matches(".*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?].*")) {
+            return false;
+        }
+
+        return true;
+    }
 
 }

--- a/src/main/java/com/jomariabejo/connectly_api/service/EmailService.java
+++ b/src/main/java/com/jomariabejo/connectly_api/service/EmailService.java
@@ -32,4 +32,57 @@ public class EmailService {
             throw new RuntimeException("Failed to send verification email", e);
         }
     }
+
+    public void sendPasswordResetEmailWithLink(String toEmail, String resetLink) {
+        try {
+            SimpleMailMessage mailMessage = new SimpleMailMessage();
+            mailMessage.setTo(toEmail);
+            mailMessage.setFrom("noreply@yourdomain.com");
+            mailMessage.setSubject("Password Reset Request");
+            
+            String emailBody = "You requested a password reset for your Connectly account.\n\n"
+                    + "Click the link below to reset your password:\n"
+                    + resetLink + "\n\n"
+                    + "This link will expire in 15 minutes.\n\n"
+                    + "If you did not request this, please ignore this email and your password will remain unchanged.\n"
+                    + "For security reasons, we'll never ask you for your password via email.\n\n"
+                    + "For your protection, this link is unique to your account and can only be used once.";
+            
+            mailMessage.setText(emailBody);
+
+            logger.info("Sending password reset email to: " + toEmail);
+            mailSender.send(mailMessage);
+            logger.info("Password reset email sent successfully");
+        } catch (Exception e) {
+            logger.error("Failed to send password reset email", e);
+            throw new RuntimeException("Failed to send password reset email", e);
+        }
+    }
+
+    public void sendPasswordResetOtp(String toEmail, String otp) {
+        try {
+            SimpleMailMessage mailMessage = new SimpleMailMessage();
+            mailMessage.setTo(toEmail);
+            mailMessage.setFrom("noreply@yourdomain.com");
+            mailMessage.setSubject("Your Password Reset Code");
+            
+            String emailBody = "You requested a password reset for your Connectly account.\n\n"
+                    + "Your password reset verification code is:\n\n"
+                    + otp + "\n\n"
+                    + "This code will expire in 15 minutes.\n"
+                    + "You can attempt to enter this code 3 times before requesting a new one.\n\n"
+                    + "If you did not request this, please ignore this email and your password will remain unchanged.\n"
+                    + "For security reasons, we'll never ask you for your password via email.\n\n"
+                    + "Do not share this code with anyone. Connectly support will never ask for this code.";
+            
+            mailMessage.setText(emailBody);
+
+            logger.info("Sending password reset OTP to: " + toEmail);
+            mailSender.send(mailMessage);
+            logger.info("Password reset OTP email sent successfully");
+        } catch (Exception e) {
+            logger.error("Failed to send password reset OTP email", e);
+            throw new RuntimeException("Failed to send password reset OTP email", e);
+        }
+    }
 }

--- a/src/main/java/com/jomariabejo/connectly_api/service/PasswordResetTokenService.java
+++ b/src/main/java/com/jomariabejo/connectly_api/service/PasswordResetTokenService.java
@@ -1,0 +1,188 @@
+package com.jomariabejo.connectly_api.service;
+
+import com.jomariabejo.connectly_api.exception.InvalidPasswordResetTokenException;
+import com.jomariabejo.connectly_api.exception.PasswordResetAttemptsExceededException;
+import com.jomariabejo.connectly_api.exception.PasswordResetTokenExpiredException;
+import com.jomariabejo.connectly_api.model.PasswordResetToken;
+import com.jomariabejo.connectly_api.model.User;
+import com.jomariabejo.connectly_api.repository.PasswordResetTokenRepository;
+import com.jomariabejo.connectly_api.util.OtpGenerator;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetTokenService {
+    private static final Logger logger = LoggerFactory.getLogger(PasswordResetTokenService.class);
+
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+
+    @Value("${security.password.reset.max-otp-attempts:3}")
+    private int maxOtpAttempts;
+
+    /**
+     * Creates a password reset token for email delivery
+     */
+    @Transactional
+    public String createEmailResetToken(User user) {
+        logger.debug("Creating email reset token for user: {}", user.getEmail());
+        
+        // Invalidate any previous unused tokens for this user
+        invalidateUserTokens(user);
+
+        String token = OtpGenerator.generateSecureToken();
+        PasswordResetToken resetToken = new PasswordResetToken(token, user);
+        resetToken.setTokenType(PasswordResetToken.TokenType.LINK);
+
+        passwordResetTokenRepository.save(resetToken);
+        logger.info("Email reset token created for user: {}", user.getEmail());
+        
+        return token;
+    }
+
+    /**
+     * Creates a password reset token with OTP for OTP delivery
+     */
+    @Transactional
+    public String createOtpResetToken(User user) {
+        logger.debug("Creating OTP reset token for user: {}", user.getEmail());
+        
+        // Invalidate any previous unused tokens for this user
+        invalidateUserTokens(user);
+
+        String token = OtpGenerator.generateSecureToken();
+        String otp = OtpGenerator.generateOtp();
+        PasswordResetToken resetToken = new PasswordResetToken(token, otp, user, PasswordResetToken.TokenType.OTP);
+
+        passwordResetTokenRepository.save(resetToken);
+        logger.info("OTP reset token created for user: {}", user.getEmail());
+        
+        return otp; // Return OTP for sending to user
+    }
+
+    /**
+     * Invalidates all unused tokens for a user
+     */
+    @Transactional
+    public void invalidateUserTokens(User user) {
+        logger.debug("Invalidating all unused tokens for user: {}", user.getEmail());
+        
+        List<PasswordResetToken> unusedTokens = passwordResetTokenRepository.findAllUnusedByUser(user);
+        for (PasswordResetToken token : unusedTokens) {
+            token.setUsed(true);
+            passwordResetTokenRepository.save(token);
+        }
+        
+        logger.debug("Invalidated {} tokens for user: {}", unusedTokens.size(), user.getEmail());
+    }
+
+    /**
+     * Validates a reset token (for email-based reset)
+     */
+    @Transactional
+    public PasswordResetToken validateToken(String token) {
+        logger.debug("Validating password reset token: {}", token);
+        
+        Optional<PasswordResetToken> resetToken = passwordResetTokenRepository.findByToken(token);
+        
+        if (resetToken.isEmpty()) {
+            logger.warn("Invalid password reset token: {}", token);
+            throw new InvalidPasswordResetTokenException("Invalid password reset token");
+        }
+
+        PasswordResetToken prt = resetToken.get();
+
+        if (prt.isExpired()) {
+            logger.warn("Password reset token expired for user: {}", prt.getUser().getEmail());
+            throw new PasswordResetTokenExpiredException("Password reset token has expired");
+        }
+
+        if (prt.isUsed()) {
+            logger.warn("Password reset token already used for user: {}", prt.getUser().getEmail());
+            throw new InvalidPasswordResetTokenException("Password reset token has already been used");
+        }
+
+        logger.info("Password reset token validated successfully for user: {}", prt.getUser().getEmail());
+        return prt;
+    }
+
+    /**
+     * Validates an OTP (for OTP-based reset)
+     */
+    @Transactional
+    public PasswordResetToken validateOtp(String otp) {
+        logger.debug("Validating OTP");
+        
+        Optional<PasswordResetToken> resetToken = passwordResetTokenRepository.findByOtp(otp);
+        
+        if (resetToken.isEmpty()) {
+            logger.warn("Invalid OTP");
+            throw new InvalidPasswordResetTokenException("Invalid OTP");
+        }
+
+        PasswordResetToken prt = resetToken.get();
+
+        if (prt.isExpired()) {
+            logger.warn("OTP expired for user: {}", prt.getUser().getEmail());
+            throw new PasswordResetTokenExpiredException("OTP has expired");
+        }
+
+        if (prt.isUsed()) {
+            logger.warn("OTP already used for user: {}", prt.getUser().getEmail());
+            throw new InvalidPasswordResetTokenException("OTP has already been used");
+        }
+
+        // Check attempt count
+        if (prt.getAttemptCount() >= maxOtpAttempts) {
+            logger.warn("Max OTP attempts exceeded for user: {}", prt.getUser().getEmail());
+            prt.setUsed(true);
+            passwordResetTokenRepository.save(prt);
+            throw new PasswordResetAttemptsExceededException(
+                "Maximum OTP validation attempts exceeded. Please request a new OTP."
+            );
+        }
+
+        // Increment attempt count
+        prt.setAttemptCount(prt.getAttemptCount() + 1);
+        passwordResetTokenRepository.save(prt);
+
+        logger.info("OTP validated successfully for user: {}", prt.getUser().getEmail());
+        return prt;
+    }
+
+    /**
+     * Marks a token as used after successful password reset
+     */
+    @Transactional
+    public void markTokenAsUsed(PasswordResetToken token) {
+        logger.debug("Marking token as used for user: {}", token.getUser().getEmail());
+        
+        token.setUsed(true);
+        passwordResetTokenRepository.save(token);
+        
+        logger.info("Token marked as used for user: {}", token.getUser().getEmail());
+    }
+
+    /**
+     * Deletes expired tokens
+     */
+    @Transactional
+    public void deleteExpiredTokens() {
+        logger.debug("Deleting expired password reset tokens");
+        
+        List<PasswordResetToken> expiredTokens = passwordResetTokenRepository.findExpiredTokens();
+        if (!expiredTokens.isEmpty()) {
+            passwordResetTokenRepository.deleteAll(expiredTokens);
+            logger.info("Deleted {} expired password reset tokens", expiredTokens.size());
+        } else {
+            logger.debug("No expired password reset tokens found");
+        }
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/service/RateLimitingService.java
+++ b/src/main/java/com/jomariabejo/connectly_api/service/RateLimitingService.java
@@ -1,0 +1,93 @@
+package com.jomariabejo.connectly_api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class RateLimitingService {
+    private static final Logger logger = LoggerFactory.getLogger(RateLimitingService.class);
+
+    // In-memory tracking of attempts (for simplicity; use Redis in production)
+    private final Map<String, AttemptTracker> attemptTrackers = new ConcurrentHashMap<>();
+
+    @Value("${security.password.reset.max-attempts:5}")
+    private int maxForgotPasswordAttempts;
+
+    @Value("${security.password.reset.attempt-window-minutes:60}")
+    private int attemptWindowMinutes;
+
+    /**
+     * Records an attempt for the given email and action
+     */
+    public void recordAttempt(String email, String action) {
+        String key = email + ":" + action;
+        long now = System.currentTimeMillis();
+        long windowStart = now - (attemptWindowMinutes * 60 * 1000L);
+
+        attemptTrackers.putIfAbsent(key, new AttemptTracker());
+        AttemptTracker tracker = attemptTrackers.get(key);
+
+        // Remove old attempts outside the window
+        tracker.attempts.removeIf(timestamp -> timestamp < windowStart);
+
+        // Add new attempt
+        tracker.attempts.add(now);
+
+        logger.debug("Recorded attempt for {}: {} attempts in window", key, tracker.attempts.size());
+    }
+
+    /**
+     * Checks if the provided email and action is rate limited
+     */
+    public boolean isRateLimited(String email, String action) {
+        String key = email + ":" + action;
+        long now = System.currentTimeMillis();
+        long windowStart = now - (attemptWindowMinutes * 60 * 1000L);
+
+        AttemptTracker tracker = attemptTrackers.get(key);
+
+        if (tracker == null) {
+            return false;
+        }
+
+        // Count attempts within the window
+        long attemptCount = tracker.attempts.stream()
+            .filter(timestamp -> timestamp >= windowStart)
+            .count();
+
+        boolean isLimited = attemptCount >= maxForgotPasswordAttempts;
+
+        if (isLimited) {
+            logger.warn("Rate limit exceeded for {}: {} attempts", key, attemptCount);
+        }
+
+        return isLimited;
+    }
+
+    /**
+     * Clears all attempt tracking (run periodically)
+     */
+    @Scheduled(fixedRateString = "${security.password.reset.attempt-cache-clear-interval:3660000}")
+    public void clearAttemptTrackers() {
+        logger.info("Clearing all rate limit attempt trackers");
+        attemptTrackers.clear();
+    }
+
+    /**
+     * Inner class to track attempts
+     */
+    private static class AttemptTracker {
+        java.util.List<Long> attempts = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+    }
+}

--- a/src/main/java/com/jomariabejo/connectly_api/util/OtpGenerator.java
+++ b/src/main/java/com/jomariabejo/connectly_api/util/OtpGenerator.java
@@ -1,0 +1,18 @@
+package com.jomariabejo.connectly_api.util;
+
+import java.security.SecureRandom;
+
+public class OtpGenerator {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int OTP_LENGTH = 6;
+    private static final int MAX_OTP_VALUE = 1000000; // 999999 + 1
+
+    public static String generateOtp() {
+        int otp = SECURE_RANDOM.nextInt(MAX_OTP_VALUE);
+        return String.format("%06d", otp);
+    }
+
+    public static String generateSecureToken() {
+        return java.util.UUID.randomUUID().toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,3 +84,12 @@ logging.level.com.jomariabejo.connectly_api=DEBUG
 # server.ssl.key-store-password=your-password
 # server.ssl.key-store-type=JKS
 # server.ssl.key-alias=selfsigned
+
+# Password Reset Configuration
+security.password.reset.expiry.minutes=15
+security.password.reset.max-attempts=5
+security.password.reset.attempt-window-minutes=60
+security.password.reset.max-otp-attempts=3
+security.password.reset.cleanup-interval=3600000
+security.password.validation.min-length=8
+app.password-reset.redirect-url=http://localhost:8080/reset-password

--- a/src/main/resources/docs/http-template/auth/forgot-password-email.http
+++ b/src/main/resources/docs/http-template/auth/forgot-password-email.http
@@ -1,0 +1,7 @@
+### Forgot Password - Email Link
+POST http://localhost:8080/auth/forgot-password/email
+Content-Type: application/json
+
+{
+  "email": "user@example.com"
+}

--- a/src/main/resources/docs/http-template/auth/forgot-password-otp.http
+++ b/src/main/resources/docs/http-template/auth/forgot-password-otp.http
@@ -1,0 +1,7 @@
+### Forgot Password - OTP
+POST http://localhost:8080/auth/forgot-password/otp
+Content-Type: application/json
+
+{
+  "email": "user@example.com"
+}

--- a/src/main/resources/docs/http-template/auth/reset-password.http
+++ b/src/main/resources/docs/http-template/auth/reset-password.http
@@ -1,0 +1,21 @@
+### Reset Password - Using Email Token
+POST http://localhost:8080/auth/reset-password
+Content-Type: application/json
+
+{
+  "token": "your-reset-token-here",
+  "otp": null,
+  "newPassword": "NewSecurePassword123!"
+}
+
+###
+
+### Reset Password - Using OTP
+POST http://localhost:8080/auth/reset-password
+Content-Type: application/json
+
+{
+  "token": null,
+  "otp": "123456",
+  "newPassword": "NewSecurePassword123!"
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -230,3 +230,50 @@ CREATE TABLE IF NOT EXISTS verification_token (
     -- Foreign key constraint linking the token to a user
     FOREIGN KEY (user_id) REFERENCES app_user (id) ON DELETE CASCADE
 );
+
+-- ==========================================================
+-- Password Reset Token Table
+-- ==========================================================
+-- This table stores password reset tokens for the forgot password flow.
+-- Supports both email-based tokens and OTP-based resets.
+
+CREATE TABLE IF NOT EXISTS password_reset_token (
+    -- Unique identifier for the token (primary key)
+    id              BIGSERIAL PRIMARY KEY,
+
+    -- Token string for email-based reset (unique, not null)
+    token           VARCHAR(255) UNIQUE,
+
+    -- OTP for OTP-based reset (optional)
+    otp             VARCHAR(10),
+
+    -- Type of token: LINK (email) or OTP
+    token_type      VARCHAR(50) NOT NULL,
+
+    -- Reference to the user (foreign key)
+    user_id         BIGINT NOT NULL,
+
+    -- Creation timestamp
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    -- Expiration date and time
+    expiry_date     TIMESTAMP NOT NULL,
+
+    -- Whether the token has been used
+    is_used         BOOLEAN DEFAULT FALSE NOT NULL,
+
+    -- Number of validation attempts (for OTP)
+    attempt_count   INTEGER DEFAULT 0 NOT NULL,
+
+    -- Foreign key constraint linking the token to a user
+    FOREIGN KEY (user_id) REFERENCES app_user (id) ON DELETE CASCADE,
+
+    -- Index for faster lookups
+    UNIQUE (token)
+);
+
+-- Create index on user_id for faster queries when finding tokens by user
+CREATE INDEX IF NOT EXISTS idx_password_reset_token_user_id ON password_reset_token(user_id);
+
+-- Create index on expiry_date for faster cleanup queries
+CREATE INDEX IF NOT EXISTS idx_password_reset_token_expiry_date ON password_reset_token(expiry_date);


### PR DESCRIPTION
- Add password reset endpoints: /auth/forgot-password/{email,otp}, /auth/reset-password
- Implement rate limiting (5 reqs/hour), token expiry (15min), and audit logging
- Create PasswordResetToken entity, PasswordResetTokenService, RateLimitingService, AuditService
- Add email templates for reset link and OTP delivery
- Prevent email enumeration with generic responses
- Validate password strength (8+ chars, uppercase, number, special char)
- Support both email-link and OTP-based password reset methods